### PR TITLE
Remove domain support

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -25,11 +25,7 @@ function Connection(options) {
 function bindToCurrentDomain(callback) {
   if (!callback) return;
 
-  var domain = process.domain;
-
-  return domain
-    ? domain.bind(callback)
-    : callback;
+  return callback;
 }
 
 Connection.createQuery = function createQuery(sql, values, callback) {

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -221,9 +221,7 @@ Pool.prototype._enqueueCallback = function _enqueueCallback(callback) {
   }
 
   // Bind to domain, as dequeue will likely occur in a different domain
-  var cb = process.domain
-    ? process.domain.bind(callback)
-    : callback;
+  var cb = callback;
 
   this._connectionQueue.push(cb);
   this.emit('enqueue');


### PR DESCRIPTION
Not sure where exactly the bug/error is here, but:

After running some tests uncaught exception no longer reached process.on("uncaughtException"). Interestingly this not happened right away but after some runs.

This PR removes domain support.
